### PR TITLE
Fix issue with account being left without a user relation

### DIFF
--- a/src/core/session/payload.ts
+++ b/src/core/session/payload.ts
@@ -77,6 +77,9 @@ export class PayloadSession {
     }
 
     if (accounts.docs.length > 0) {
+      data["sub"] = accountInfo.sub
+      data["issuerName"] = issuerName
+      data["user"] = userID
       await payload.update({
         collection: this.#collections.accountsCollectionSlug,
         where: {


### PR DESCRIPTION
This fixes an issue where if a user is deleted the accounts will no longer have a relation but still allow the login as the `sub` field is still correct. 

To replicate the issue run the plugin with `allowSignUp: true` and login using desired provider. 
With a user now created and working, logout, now delete the user from the admin dashboard. The account will now show undefined. This is a separate issue where a hook probably needs to be added to remove all accounts associated with a user. 

Now login again and the user will be created without updating the account to match the new user. 

This pull request fixes this issue and updates the account on every login with updated info from the Auth provider. 

Tested with Auth0. 