### PR TITLE
fix: add support for non standard api path in sign in function

### DIFF
--- a/src/client/signin.ts
+++ b/src/client/signin.ts
@@ -14,12 +14,12 @@ type Provider =
   | "discord"
   | "facebook"
 
-export function signin(provider: Provider) {
+export function signin(provider: Provider, apiBase: string = '/api') {
   if (provider === "passkey") {
     init()
   } else {
     const link = document.createElement("a")
-    link.href = "/api/admin/oauth/authorization/" + provider
+    link.href = `${apiBase}/admin/oauth/authorization/${provider}`
     link.click()
   }
 }


### PR DESCRIPTION
For Payload instances where the base REST API path is not the default (see [relevant Payload docs](https://payloadcms.com/docs/admin/overview#root-level-routes)), the current sign in function does not work, as it is hardcoded to navigate to `/api/<endpoint>`, where it should go to `<base-api-path>/<endpoint>`. This PR adds an optional argument to the sign in function where users can pass their REST API base path.

You can test this by creating a Payload instance and changing the REST API base path. For example:

```
export default buildConfig({
	routes: {
		api: '/api/payload',
	},
}
```

Without this change, the `signing()` function redirects the user to `/api/admin/oauth/authorization/<provider>`, which results in a 404. With this change, users can pass their base path, which fixes that issue.