### PR TITLE
feat: adding support for client_secret_basic auth method.

### DIFF
--- a/src/core/protocols/oauth/oauth2_callback.ts
+++ b/src/core/protocols/oauth/oauth2_callback.ts
@@ -18,13 +18,14 @@ export async function OAuth2Callback(
     throw new MissingOrInvalidSession()
   }
 
-  const { client_id, client_secret, authorization_server, profile } =
+  const { client_id, client_secret, authorization_server, profile, client_auth_type } =
     providerConfig
 
   const client: oauth.Client = {
     client_id,
   }
-  const clientAuth = oauth.ClientSecretPost(client_secret ?? "")
+
+  const clientAuth = client_auth_type === "client_secret_basic" ? oauth.ClientSecretBasic(client_secret ?? "") : oauth.ClientSecretPost(client_secret ?? "");
 
   const current_url = new URL(request.url as string) as URL
   const callback_url = getCallbackURL(

--- a/src/types.ts
+++ b/src/types.ts
@@ -33,7 +33,8 @@ export interface OAuth2ProviderConfig
   extends BaseProviderConfig,
     ProviderConfig {
   authorization_server: AuthorizationServer
-  algorithm: "oauth2"
+  algorithm: "oauth2",
+  client_auth_type?: "client_secret_basic" | "client_secret_post"
 }
 
 export type OAuthProviderConfig = OIDCProviderConfig | OAuth2ProviderConfig

--- a/src/types.ts
+++ b/src/types.ts
@@ -18,6 +18,10 @@ export interface ProviderConfig {
    * Oauth provider Client Secret
    */
   client_secret?: string
+   /*
+   * Oauth provider Client Type
+   */
+  client_auth_type?: "client_secret_basic" | "client_secret_post"
   /*
    * Additional parameters you would like to add to query for the provider
    */
@@ -33,8 +37,7 @@ export interface OAuth2ProviderConfig
   extends BaseProviderConfig,
     ProviderConfig {
   authorization_server: AuthorizationServer
-  algorithm: "oauth2",
-  client_auth_type?: "client_secret_basic" | "client_secret_post"
+  algorithm: "oauth2"
 }
 
 export type OAuthProviderConfig = OIDCProviderConfig | OAuth2ProviderConfig


### PR DESCRIPTION
The OAuth callback in src/core/protocols/oauth/oauth2_callback.ts was forcing `client_secret_post` as the auth method. `oauth4webapi` supports both `client_secret_basic` and `client_secret_post`. This change allows providers to leverage `client_secret_basic` if they choose. It will default to `client_secret_post` if no config is provided, as that is best practice and should be preferred.