### PR TITLE
fix: bug in cookie expiration time is not in UTC

### DIFF
--- a/src/core/session/payload.ts
+++ b/src/core/session/payload.ts
@@ -126,7 +126,7 @@ export class PayloadSession {
 
     const cookies: string[] = []
     cookies.push(
-      `${payload.config.cookiePrefix!}-token=${token};Path=/;HttpOnly;SameSite=lax;Expires=${cookieExpiration.toString()}`,
+      `${payload.config.cookiePrefix!}-token=${token};Path=/;HttpOnly;SameSite=lax;Expires=${cookieExpiration.toUTCString()}`,
     )
     const expired = "Thu, 01 Jan 1970 00:00:00 GMT"
     cookies.push(


### PR DESCRIPTION
Cookie expirations need to be in UTC. In cases where the server is not configured to use UTC, the `cookieExpiration.toString()` will result in a timezone in the cookie expiration string (i.e. `payload-token=***********;Path=/;HttpOnly;SameSite=lax;Expires=Sun Feb 09 2025 11:18:31 GMT-0700 (Mountain Standard Time).`) By switching this to toUTCString() we can ensure all cookie expiration times are in UTC. This might only happen on local machines but it causes issues with development.