### PR TITLE
Update package.json to support hooks export

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
       "import": "./dist/esm/client/index.js",
       "types": "./dist/types/client/index.d.ts"
     },
-    "./hooks": {
+    "./client/hooks": {
       "import": "./dist/esm/client/hooks.js",
       "types": "./dist/types/client/hooks.d.ts"
     },

--- a/package.json
+++ b/package.json
@@ -51,6 +51,10 @@
       "import": "./dist/esm/client/index.js",
       "types": "./dist/types/client/index.d.ts"
     },
+    "./hooks": {
+      "import": "./dist/esm/client/hooks.js",
+      "types": "./dist/types/client/hooks.d.ts"
+    },
     "./collection": {
       "import": "./dist/esm/collection/index.js",
       "types": "./dist/types/collection/index.d.ts"


### PR DESCRIPTION
Hooks are exported as payload-auth-plugin/hooks

Example,
import { getCurrentUser } from 'payload-auth-plugin/hooks'