### PR TITLE
Update jumpcloud.ts

### DIFF
--- a/src/providers/oauth2/jumpcloud.ts
+++ b/src/providers/oauth2/jumpcloud.ts
@@ -73,6 +73,7 @@ function JumpCloudAuthProvider(
     authorization_server,
     name: "Jump Cloud",
     algorithm: "oauth2",
+    kind: "oauth",
     profile: (profile): AccountInfo => {
       return {
         sub: profile.email as string,


### PR DESCRIPTION
fix: jumpcloud config is missing a `type` attribute