### PR TITLE
fix: use serverURL instead of request.origin for OAuth redirect in containers

### DIFF
--- a/src/core/protocols/oauth/oauth_authentication.ts
+++ b/src/core/protocols/oauth/oauth_authentication.ts
@@ -107,7 +107,7 @@ export async function OAuthAuthentication(
   ]
   cookies = invalidateOAuthCookies(cookies)
   const successRedirectionURL = new URL(
-    `${request.origin}${successRedirectPath}`,
+    `${payload.config.serverURL}${successRedirectPath}`,
   )
   const res = new Response(null, {
     status: 302,


### PR DESCRIPTION
# Fix: Use serverURL instead of request.origin for OAuth redirect in containers

## Problem
In dockerized environments, `request.origin` returns the internal container name instead of the actual server URL, causing OAuth success redirects to fail.

## Solution
Replace `request.origin` with `payload.config.serverURL` when constructing the OAuth success redirection URL.

## Changes
- Updated OAuth redirect URL construction to use `payload.config.serverURL`
- Ensures proper redirect behavior in containerized deployments

## Testing
- Test OAuth flow in a dockerized environment
- Verify successful redirect after OAuth authentication
- Confirm behavior works when Payload app and frontend share the same URL

## Notes
This solution works well for setups where the Payload app and frontend are on the same URL. Future enhancement could make this configurable via provider or plugin config for additional flexibility.

---