### PR TITLE
Fix - removed string generation for cognito issuer

### DIFF
--- a/src/providers/oidc/cognito.ts
+++ b/src/providers/oidc/cognito.ts
@@ -44,7 +44,7 @@ function CognitoAuthProvider(config: CognitoAuthConfig): OIDCProviderConfig {
     ...restConfig,
     id: "cognito",
     scope: "email openid profile",
-    issuer: `https://${domain}/${region}`,
+    issuer: domain,
     name: "Congnito",
     algorithm: "oidc",
     kind: "oauth",


### PR DESCRIPTION
Places the entire domain within the CotgnitoAuthRrovider config eliminating the 404 error for those who are copying the cognito domain directly. This will also future proof the config for any changes AWS might make to their domain generation.