### PR TITLE
Feat - Add scope to cognito interface in case custom

### DIFF
--- a/src/providers/oidc/cognito.ts
+++ b/src/providers/oidc/cognito.ts
@@ -7,6 +7,7 @@ import type {
 interface CognitoAuthConfig extends OAuthBaseProviderConfig {
   domain: string
   region: string
+  scope?: string
 }
 
 /**
@@ -39,11 +40,11 @@ interface CognitoAuthConfig extends OAuthBaseProviderConfig {
  */
 
 function CognitoAuthProvider(config: CognitoAuthConfig): OIDCProviderConfig {
-  const { domain, region, ...restConfig } = config
+  const { domain, region, scope, ...restConfig } = config
   return {
     ...restConfig,
     id: "cognito",
-    scope: "email openid profile",
+    scope: scope || "email openid profile",
     issuer: `https://${domain}/${region}`,
     name: "Congnito",
     algorithm: "oidc",


### PR DESCRIPTION
Add the ability for people to set their own scope within the AWS Cognito config and if none then default to the original.