### PR TITLE
feat: add access_token field to accounts collection to enable the use of googleapis

### DIFF
--- a/src/collection/index.ts
+++ b/src/collection/index.ts
@@ -145,6 +145,10 @@ export const withAccountCollection = (
       required: true,
     },
     {
+      name: "access_token",
+      type: "text",
+    },
+    {
       name: "passkey",
       type: "group",
       fields: [

--- a/src/core/protocols/oauth/oauth2_callback.ts
+++ b/src/core/protocols/oauth/oauth2_callback.ts
@@ -1,8 +1,8 @@
-import { parseCookies, type PayloadRequest } from "payload"
 import * as oauth from "oauth4webapi"
+import { parseCookies, type PayloadRequest } from "payload"
 import type { OAuth2ProviderConfig } from "../../../types.js"
-import { getCallbackURL } from "../../utils/cb.js"
 import { MissingOrInvalidSession } from "../../errors/consoleErrors.js"
+import { getCallbackURL } from "../../utils/cb.js"
 import { OAuthAuthentication } from "./oauth_authentication.js"
 
 export async function OAuth2Callback(
@@ -85,6 +85,7 @@ export async function OAuth2Callback(
     scope: providerConfig.scope,
     issuer: providerConfig.authorization_server.issuer,
     picture: userInfo.picture ?? "",
+    access_token: token_result.access_token,
   }
 
   return await OAuthAuthentication(

--- a/src/core/protocols/oauth/oauth_authentication.ts
+++ b/src/core/protocols/oauth/oauth_authentication.ts
@@ -1,14 +1,11 @@
-import type { JsonObject, TypeWithID, PayloadRequest } from "payload"
-import {
-  InvalidRequestBodyError,
-  UserNotFoundAPIError,
-} from "../../errors/apiErrors.js"
 import * as jose from "jose"
+import type { JsonObject, PayloadRequest, TypeWithID } from "payload"
+import { APP_COOKIE_SUFFIX } from "../../../constants.js"
+import { UserNotFoundAPIError } from "../../errors/apiErrors.js"
 import {
   createSessionCookies,
   invalidateOAuthCookies,
 } from "../../utils/cookies.js"
-import { APP_COOKIE_SUFFIX } from "../../../constants.js"
 
 export async function OAuthAuthentication(
   pluginType: string,
@@ -29,9 +26,18 @@ export async function OAuthAuthentication(
     scope: string
     issuer: string
     picture?: string | undefined
+    access_token: string
   },
 ): Promise<Response> {
-  const { email: _email, sub, name, scope, issuer, picture } = account
+  const {
+    email: _email,
+    sub,
+    name,
+    scope,
+    issuer,
+    picture,
+    access_token,
+  } = account
   const { payload } = request
 
   const email = _email.toLowerCase()
@@ -49,7 +55,7 @@ export async function OAuthAuthentication(
     userRecord = userRecords.docs[0]
   } else if (allowOAuthAutoSignUp) {
     const data: Record<string, unknown> = {
-      email: email,
+      email,
     }
     const hasAuthEnabled = Boolean(
       payload.collections[collections.usersCollection].config.auth,
@@ -73,6 +79,7 @@ export async function OAuthAuthentication(
     name: name,
     picture: picture,
     issuerName: issuer,
+    access_token,
   }
 
   const accountRecords = await payload.find({

--- a/src/core/protocols/oauth/oidc_callback.ts
+++ b/src/core/protocols/oauth/oidc_callback.ts
@@ -1,13 +1,13 @@
-import { parseCookies, type PayloadRequest } from "payload"
 import * as oauth from "oauth4webapi"
-import type { AccountInfo, OIDCProviderConfig } from "../../../types.js"
-import { getCallbackURL } from "../../utils/cb.js"
-import { MissingOrInvalidSession } from "../../errors/consoleErrors.js"
+import { parseCookies, type PayloadRequest } from "payload"
+import type { OIDCProviderConfig } from "../../../types.js"
 import {
   InternalServerError,
   MissingEmailAPIError,
   UnVerifiedAccountAPIError,
 } from "../../errors/apiErrors.js"
+import { MissingOrInvalidSession } from "../../errors/consoleErrors.js"
+import { getCallbackURL } from "../../utils/cb.js"
 import { OAuthAuthentication } from "./oauth_authentication.js"
 
 export async function OIDCCallback(
@@ -119,6 +119,7 @@ export async function OIDCCallback(
     scope: providerConfig.scope,
     issuer: providerConfig.issuer,
     picture: result.picture ?? "",
+    access_token: token_result.access_token,
   }
 
   return await OAuthAuthentication(

--- a/src/types.ts
+++ b/src/types.ts
@@ -110,6 +110,7 @@ export interface AccountInfo {
     deviceType: string
     backedUp: boolean
   }
+  access_token?: string
 }
 
 export type PasswordProviderConfig = {


### PR DESCRIPTION
store `access_token` in account collection and include access_token in authentication response

### The purpose of the changes
I want to be able to use googleapis. For authentication, one needs the `access_token`. `access_token` is already available with the current logic, but it's not saved to the account collection. This PR does it.

### Instructions on how to test the changes.
1. Follow the docs to work in the example
2. login / sign up
3. Check if the `access_token` is saved to the account collection in the db