### PR TITLE
fix: include name in user creation data for OAuth auto sign-up

### DIFF
--- a/src/core/protocols/oauth/oauth_authentication.ts
+++ b/src/core/protocols/oauth/oauth_authentication.ts
@@ -49,7 +49,8 @@ export async function OAuthAuthentication(
     userRecord = userRecords.docs[0]
   } else if (allowOAuthAutoSignUp) {
     const data: Record<string, unknown> = {
-      email: email,
+      email,
+      name,
     }
     const hasAuthEnabled = Boolean(
       payload.collections[collections.usersCollection].config.auth,


### PR DESCRIPTION
This adds the name into the user creation, that gets populated by the oauth.