### PR TITLE
feat: updated Microsoft Entra auth URL

### DIFF
--- a/src/providers/oidc/microsoft-entra.ts
+++ b/src/providers/oidc/microsoft-entra.ts
@@ -52,7 +52,7 @@ function MicrosoftEntraAuthProvider(
     ...restConfig,
     id: "msft-entra",
     scope: overrideScope ?? "openid profile email offline_access",
-    issuer: `https://login.microsoftonline.com/${config.tenant_id}/v2.0`,
+    issuer: `https://${config.tenant_id}.ciamlogin.com/${config.tenant_id}/v2.0`,
     name: "Microsoft Entra",
     algorithm: "oidc",
     kind: "oauth",


### PR DESCRIPTION
Problem:
When using microsoftonline.com domain, users authenticating without a work or school account receive this error:
AADSTS500208: The domain is not a valid login domain for the account type.

Azure Active Directory (AAD) used microsoftonline.com, Microsoft Entra has migrated to ciamlogin.com
This change works for all Microsoft Entra account types.

Fix:
Change the url used to ciamlogin.com

