### PR TITLE
fix: add fallback if userInfo.sub is not available

### DIFF
--- a/src/core/protocols/oauth/oauth2_callback.ts
+++ b/src/core/protocols/oauth/oauth2_callback.ts
@@ -81,7 +81,7 @@ export async function OAuth2Callback(
   const userData = {
     email: userInfo.email,
     name: userInfo.name ?? "",
-    sub: userInfo.sub,
+    sub: userInfo.sub ?? userInfo.id,
     scope: providerConfig.scope,
     issuer: providerConfig.authorization_server.issuer,
     picture: userInfo.picture ?? "",


### PR DESCRIPTION
## Problem
When trying to authenticate using a provider not returning a `sub` field during the userInfo request, the plugin fails with a message: `The following field is invalid: Sub`. This is especially the case with Github and Discord.

 ## Solution
 Use the `id` field returned during the userInfo request as a fallback. If that's not available, the whole thing will continue to fail.
 
 ## See also
 Fixes #133 

