### PR TITLE
Fix: always pass tokenExpiration for frontend session cookies

### DIFF
--- a/src/core/protocols/oauth/oauth_authentication.ts
+++ b/src/core/protocols/oauth/oauth_authentication.ts
@@ -167,7 +167,7 @@ export async function OAuthAuthentication(
         sid: sessionID,
         collection: collections.usersCollection,
       },
-      useAdmin ? collectionConfig?.auth.tokenExpiration : undefined,
+      collectionConfig?.auth.tokenExpiration,
       collectionConfig.auth as SanitizedCollectionConfig["auth"] || false,
     )),
   ]

--- a/src/core/protocols/password.ts
+++ b/src/core/protocols/password.ts
@@ -146,7 +146,7 @@ export const PasswordSignin = async (
     secret,
     signinFields,
     request,
-    useAdmin ? collectionConfig.auth.tokenExpiration : undefined,
+    collectionConfig.auth.tokenExpiration,
   )
 }
 
@@ -250,7 +250,7 @@ export const PasswordSignup = async (
       secret,
       signinFields,
       request,
-      useAdmin ? collectionConfig.auth.tokenExpiration : undefined,
+      collectionConfig.auth.tokenExpiration,
     )
   }
 


### PR DESCRIPTION
## Summary

For non-admin (frontend) logins, `useAdmin` is `false`, so the ternary expression:

```ts
useAdmin ? collectionConfig.auth.tokenExpiration : undefined
```

passes `undefined` to `createSessionCookies()`, which then falls back to the hardcoded **7200s** (2 hour) default. This means the collection's configured `auth.tokenExpiration` is silently ignored for all frontend logins — only admin logins respect it.

This affects three flows:
- **OAuth authentication** (`src/core/protocols/oauth/oauth_authentication.ts`)
- **Password signin** (`src/core/protocols/password.ts` — `PasswordSignin`)
- **Password signup** (`src/core/protocols/password.ts` — `PasswordSignup`)

## Fix

Remove the `useAdmin` conditional and always pass `collectionConfig.auth.tokenExpiration` to `createSessionCookies()`, so both admin and frontend session cookies use the collection's configured token expiration.

**Before:**
```ts
useAdmin ? collectionConfig.auth.tokenExpiration : undefined
```

**After:**
```ts
collectionConfig.auth.tokenExpiration
```

## Test plan

- [ ] Configure a collection with a custom `auth.tokenExpiration` (e.g. 86400 for 24h)
- [ ] Sign in via the frontend (non-admin) using password auth and verify the session cookie expiration matches the configured value instead of defaulting to 7200s
- [ ] Sign in via the frontend using OAuth and verify the same
- [ ] Sign up with `allowAutoSignin: true` and verify the session cookie expiration is correct
- [ ] Verify admin login still works correctly with the configured expiration

🤖 Generated with [Claude Code](https://claude.com/claude-code)